### PR TITLE
Fix formal name

### DIFF
--- a/R/arg.R
+++ b/R/arg.R
@@ -21,6 +21,9 @@
 #'     the function; if there was no default, \code{expr} is the
 #'     missing argument (see \code{\link{arg_missing}()}).}
 #'
+#'   \item{name}{The name of the formal argument to which \code{expr}
+#'     was originally supplied.}
+#'
 #'   \item{eval_frame}{The frame providing the scope for \code{expr},
 #'     which should normally be evaluated in \code{eval_frame$env}.
 #'     This is normally the original calling frame, unless the
@@ -72,6 +75,7 @@ arg_info_ <- function(expr, stack) {
     # explicitely. The evaluation frame of missing arguments is the
     # current frame, but the caller is the next one
     if (missing(caller_expr)) {
+      formal_name <- as.character(expr)
       expr <- fml_default(expr, eval_frame$fn)
       caller_frame <- stack[[i + 1]]
       break
@@ -81,6 +85,7 @@ arg_info_ <- function(expr, stack) {
     # callee frame, and the next frame is both the caller and
     # evaluation frame
     if (!is.symbol(caller_expr)) {
+      formal_name <- as.character(expr)
       expr <- caller_expr
       caller_frame <- stack[[i + 1]]
       eval_frame <- stack[[i + 1]]
@@ -89,11 +94,13 @@ arg_info_ <- function(expr, stack) {
 
     # If the argument matched in the caller signature is another
     # symbol, record it and move on to next frame
+    formal_name <- as.character(expr)
     expr <- caller_expr
   }
 
   list(
     expr = maybe_missing(expr),
+    name = formal_name,
     eval_frame = eval_frame,
     caller_frame = caller_frame
   )

--- a/R/arg.R
+++ b/R/arg.R
@@ -113,7 +113,11 @@ arg_match <- function(sym, call) {
 fml_default <- function(expr, fn) {
   nm <- as.character(expr)
   fmls <- formals(fn)
-  fmls[[nm]]
+  if (nm %in% names(fmls)) {
+    fmls[[nm]]
+  } else {
+    arg_missing()
+  }
 }
 
 #' @export

--- a/R/call.R
+++ b/R/call.R
@@ -370,12 +370,17 @@ call_fn_name <- function(call = NULL) {
     if (identical(fn[[1]], quote(`::`)) ||
         identical(fn[[1]], quote(`:::`))) {
       # Namespaced calls: foo::bar(), foo:::bar()
-      fn <- fn[[3]]
+      return(as.character(fn[[3]]))
     } else {
       # Subsetted calls: foo@bar(), foo$bar()
       # Anomymous calls: foo[[bar]](), foo()()
       return(NULL)
     }
+  }
+
+  if (!is.symbol(fn)) {
+    # Inlined closures: (function() {})()
+    return(NULL)
   }
 
   as.character(fn)

--- a/R/dots.R
+++ b/R/dots.R
@@ -83,6 +83,9 @@ dots_info_ <- function(dots, stack) {
 }
 
 dots_enumerate_sym <- function(dots) {
+  if (!length(dots)) {
+    return(dots)
+  }
   nms <- paste0("..", seq_along(dots))
   lapply(nms, as.name)
 }

--- a/R/pairlist.R
+++ b/R/pairlist.R
@@ -16,6 +16,18 @@ lsp_walk_nonnull <- function(.x, .f, ...) {
   }
   out
 }
+lsp_walk_last <- function(.x, .f, ...) {
+  cur <- .x
+  while(!is.null(cdr(cur))) {
+    cur <- cdr(cur)
+  }
+  .f(cur, ...)
+}
+
+lsp_append <- function(.x, .y) {
+  lsp_walk_last(.x, function(l) set_cdr(l, .y))
+  .x
+}
 
 #' @useDynLib rlang car_
 car <- function(x) {

--- a/man/arg_info.Rd
+++ b/man/arg_info.Rd
@@ -29,6 +29,9 @@ A list containing:
     the function; if there was no default, \code{expr} is the
     missing argument (see \code{\link{arg_missing}()}).}
 
+  \item{name}{The name of the formal argument to which \code{expr}
+    was originally supplied.}
+
   \item{eval_frame}{The frame providing the scope for \code{expr},
     which should normally be evaluated in \code{eval_frame$env}.
     This is normally the original calling frame, unless the

--- a/man/call_standardise.Rd
+++ b/man/call_standardise.Rd
@@ -5,7 +5,7 @@
 \title{Standardise a call against formal arguments}
 \usage{
 call_standardise(call = NULL, fn = NULL, caller_env = NULL,
-  enum_dots = FALSE)
+  enum_dots = FALSE, add_missings = FALSE)
 }
 \arguments{
 \item{call}{Can be a call, a formula quoting a call in the
@@ -29,6 +29,8 @@ mostly intended for code analysis tools as it makes it easier to
 climb arguments through nested calls. The latter form (the
 default) is more faithful to the actual call and is ready to be
 evaluated.}
+
+\item{add_missings}{Whether to standardise missing arguments.}
 }
 \description{
 Compared to \code{\link{match.call}()}, \code{call_standardise()}:
@@ -42,6 +44,8 @@ Compared to \code{\link{match.call}()}, \code{call_standardise()}:
         \code{call(foo = x, ..3)}.
   \item Does not sort arguments according to the order of
         appearance in the function definition.
+  \item Standardises missing arguments as well if you specify
+        \code{add_missings}: \code{call(x = , y = , )}.
 }
 }
 

--- a/tests/testthat/test-arg.R
+++ b/tests/testthat/test-arg.R
@@ -39,6 +39,16 @@ test_that("empty argument are reported", {
   expect_identical(info$caller_frame$env, environment())
 })
 
+test_that("formals names are recorded", {
+  fn <- function(foo) arg_info(foo)
+  expect_equal(fn()$name, "foo")
+
+  g <- function() fn(bar)
+  expect_equal(g()$name, "foo")
+
+  g <- function() fn(foo(bar))
+  expect_equal(g()$name, "foo")
+})
 
 # arg_env -----------------------------------------------------------------
 
@@ -141,7 +151,6 @@ test_that("is_missing() works with symbols", {
   x <- arg_missing()
   expect_true(is_missing(x))
 })
-
 
 test_that("is_missing() works with non-symbols", {
   expect_true(is_missing(arg_missing()))

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -214,6 +214,12 @@ test_that("call_fn() extracts function", {
   expect_identical(fn(), fn)
 })
 
+test_that("Inlined functions return NULL name", {
+  call <- quote(fn())
+  call[[1]] <- function() {}
+  expect_null(call_fn_name(call))
+})
+
 test_that("call_args() and call_args_names()", {
   expect_identical(call_args(~fn(a, b)), set_names(list(quote(a), quote(b)), c("", "")))
 

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -166,6 +166,11 @@ test_that("dots are not confused with formals", {
   expect_equal(fn(z = foo, bar, x = baz, bam), quote(fn(z = foo, y = bar, x = baz, bam)))
 })
 
+test_that("missing arguments are matched as well", {
+  fn <- function(x, y, z) call_standardise(add_missings = TRUE)
+  expect_equal(fn(y = foo), quote(fn(y = foo, x = , z = )))
+})
+
 # Modification ------------------------------------------------------------
 
 test_that("all args must be named", {

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -49,3 +49,8 @@ test_that("unmatched dots return arg_missing()", {
   expect_equal(out[[1]]$expr, arg_missing())
   expect_equal(out[[2]]$expr, arg_missing())
 })
+
+test_that("empty dots return list()", {
+  fn <- function(...) dots_info(...)
+  expect_equal(fn(), list())
+})

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -36,3 +36,16 @@ test_that("dots_info() inspects dots", {
   expect_identical(info$foo$eval_frame$env, out$env)
   expect_identical(info[[2]]$eval_frame$env, out$env)
 })
+
+test_that("unmatched dots return arg_missing()", {
+  # Only occurs with partial stack climbing. Necessary for lazyeval
+  # compatibility
+  fn <- function(...) {
+    dots <- arg_dots(...)
+    stack <- call_stack(2)
+    dots_info_(dots, stack)
+  }
+  out <- fn(, )
+  expect_equal(out[[1]]$expr, arg_missing())
+  expect_equal(out[[2]]$expr, arg_missing())
+})


### PR DESCRIPTION
This adds a `name` field to `arg_info()`'s output. It reports the name of the original formal argument. This is used in the lazyeval compatibility layer because `lazy()` returns the formal name when the argument is missing (whereas `arg_info()` and `arg_expr()` return the missing arg for consistency).

To make this possible `call_standardise()` gains a `add_missings()` argument so that `f()` is expanded to `f(x = )`. I wonder if `add_missings` and `enum_dots` should be gathered in a single bool argument `full`?