### PR TITLE
C API for signaling conditions

### DIFF
--- a/inst/include/condition.h
+++ b/inst/include/condition.h
@@ -1,0 +1,37 @@
+#ifndef CONDITION_H_
+#define CONDITION_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <Rinternals.h>
+
+static SEXP signal_condition(const char * msg, const char * class_, SEXP env = R_GlobalEnv) {
+  SEXP condition, c, signalConditionFun, out;
+
+  const char *nms[] = {"message", ""};
+  PROTECT(condition = Rf_mkNamed(VECSXP, nms));
+
+  PROTECT(c = Rf_allocVector(STRSXP, 2));
+  SET_STRING_ELT(c, 0, Rf_mkChar(class_));
+  SET_STRING_ELT(c, 1, Rf_mkChar("condition"));
+
+  SET_VECTOR_ELT(condition, 0, Rf_mkString(msg));
+  Rf_setAttrib(condition, R_ClassSymbol, c);
+  signalConditionFun = Rf_findFun(Rf_install("signalCondition"), R_BaseEnv);
+
+  SEXP call = PROTECT(Rf_lang2(signalConditionFun, condition));
+  PROTECT(out = Rf_eval(call, env));
+
+  UNPROTECT(4);
+
+  return out;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONDITION_H_ */


### PR DESCRIPTION
Because R's C API does not have a direct way to signal a condition, this
implementation simply constructs a condition object and calls the R
`signalCondition` function.

This file is located in `inst/include` so that other packages can use it
by adding `LinkingTo: rlang` to their DESCRIPTION. The function is
static so it will be copied to each compilation unit, avoiding multiple
definition errors. `inline` is not part of the c89 standard, so cannot
be used without `-std=c99` or compiler extensions.

This API assumes the condition object will contain only only one (additional) class and no additional values apart from the message, we can discuss if we should provide a more flexible API or if this is sufficient. I am also not sure if we need to expose the evaluation env, or if always evaluating the  `signalCondition()` call in the global environment is sufficient.