### PR TITLE
Avoid test failures on systems that don't have a MBCS locale

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,9 +1,11 @@
 context("utils")
 
 test_that("locale setters report old locale", {
-  skip_on_cran() # Probably not portable
-  skip_on_travis() # Limited locales available
-  old <- suppressMessages(set_mbcs_locale())
+  tryCatch(
+    old <- suppressMessages(set_mbcs_locale()),
+    warning = function(e) skip("Cannot set MBCS locale")
+  )
+
   mbcs <- suppressMessages(set_latin1_locale())
   suppressMessages(Sys.setlocale("LC_CTYPE", old))
   expect_true(tolower(mbcs) %in% tolower(c("ja_JP.SJIS", "English_United States.932")))


### PR DESCRIPTION
by aborting early on warnings in `set_mbcs_locale()`.