### PR TITLE
Fix formula self eval

### DIFF
--- a/R/tidy-capture.R
+++ b/R/tidy-capture.R
@@ -100,7 +100,7 @@ dot_f <- function(dot) {
 
   env <- dot$env
   orig <- dot$expr
-  expr <- get_expr(orig)
+  expr <- if (is_definition(orig)) f_rhs(orig) else orig
 
   # Allow unquote-splice in dots
   if (is_splice(expr)) {
@@ -110,8 +110,10 @@ dot_f <- function(dot) {
     map(dots, as_quosure, env)
   } else {
     expr <- .Call(rlang_interp, expr, env)
-    orig <- set_expr(orig, expr)
-    list(new_quosure(orig, env))
+    if (is_definition(orig)) {
+      expr <- set_expr(orig, expr)
+    }
+    list(new_quosure(expr, env))
   }
 }
 

--- a/R/tidy-capture.R
+++ b/R/tidy-capture.R
@@ -82,7 +82,14 @@ catch_quosure <- function(x) {
   capture <- new_language(captureArg, substitute(x))
   arg <- eval_bare(capture, caller_env())
   expr <- .Call(rlang_interp, arg$expr, arg$env)
-  new_quosure(expr, arg$env)
+  forward_quosure(expr, arg$env)
+}
+forward_quosure <- function(expr, env) {
+  if (is_symbolic(expr)) {
+    new_quosure(expr, env)
+  } else {
+    as_quosure(expr, empty_env())
+  }
 }
 
 dots_capture <- function(...) {
@@ -111,9 +118,11 @@ dot_f <- function(dot) {
   } else {
     expr <- .Call(rlang_interp, expr, env)
     if (is_definition(orig)) {
-      expr <- set_expr(orig, expr)
+      orig <- set_expr(orig, expr)
+      list(new_quosure(orig, env))
+    } else {
+      list(forward_quosure(expr, env))
     }
-    list(new_quosure(expr, env))
   }
 }
 

--- a/R/tidy-eval.R
+++ b/R/tidy-eval.R
@@ -303,7 +303,17 @@ f_self_eval <- function(overscope, overscope_top) {
 }
 f_unguard <- function(...) {
   tilde <- sys.call()
-  tilde[[1]] <- quote(`~`)
+  tilde[[1]] <- sym_tilde
+
+  # Formulas explicitly supplied by the user are guarded but not
+  # unquoted. We evaluate them now to get the right environment.
+  if (is_null(attr(tilde, ".Environment"))) {
+    tilde <- structure(tilde,
+      class = "formula",
+      .Environment = caller_env()
+    )
+  }
+
   tilde
 }
 

--- a/tests/testthat/test-tidy-capture.R
+++ b/tests/testthat/test-tidy-capture.R
@@ -97,9 +97,6 @@ test_that("dot names are interpolated", {
 
   var <- quote(baz)
   expect_identical(dots_quosures(!!var := foo), list(baz = ~foo))
-
-  def <- !!var := foo
-  expect_identical(dots_quosures(!! def), list(baz = ~foo))
 })
 
 test_that("corner cases are handled when interpolating dot names", {
@@ -181,4 +178,10 @@ test_that("formulas are not guarded if unquoted", {
   quo <- quosure(foo(bar))
   quo <- quosure(baz(!! quo))
   expect_equal(quo, ~baz(~foo(bar)))
+})
+
+test_that("quosured literals are forwarded as is", {
+  expect_identical(quosure(!! ~NULL), ~NULL)
+  expect_identical(quosure(!! quosure(NULL)), new_quosure(NULL, empty_env()))
+  expect_identical(dots_quosures(!! ~10L), set_names(list(~10L), ""))
 })

--- a/tests/testthat/test-tidy-capture.R
+++ b/tests/testthat/test-tidy-capture.R
@@ -157,11 +157,28 @@ test_that("can capture empty list of dots", {
 })
 
 test_that("quosures are spliced before serialisation", {
-  quosures <- dots_quosures(~foo(~bar), .named = TRUE)
+  quosures <- dots_quosures(!! ~foo(~bar), .named = TRUE)
   expect_identical(names(quosures), "foo(bar)")
 })
 
 test_that("dots_quosures() captures missing arguments", {
   q <- new_quosure(missing_arg(), empty_env())
   expect_identical(dots_quosures(, ), set_names(list(q, q), c("", "")))
+})
+
+test_that("formulas are guarded on capture", {
+  expect_identical(
+    quosure(~foo(~bar, ~~baz())),
+    quosure(`_F`(foo(`_F`(bar), `_F`(`_F`(baz())))))
+  )
+})
+
+test_that("formulas are not guarded if unquoted", {
+  expect_identical(
+    quosure(!! ~foo(~bar, ~~baz())),
+    new_quosure(~foo(~bar, ~~baz()))
+  )
+  quo <- quosure(foo(bar))
+  quo <- quosure(baz(!! quo))
+  expect_equal(quo, ~baz(~foo(bar)))
 })

--- a/tests/testthat/test-tidy-unquote.R
+++ b/tests/testthat/test-tidy-unquote.R
@@ -46,7 +46,7 @@ test_that("can interpolate in specific env", {
 
 test_that("can qualify operators with namespace", {
   # Should remove prefix only if rlang-qualified:
-  expect_identical(quosure(rlang::UQ(toupper("a"))), ~"A")
+  expect_identical(quosure(rlang::UQ(toupper("a"))), new_quosure("A", empty_env()))
   expect_identical(quosure(list(rlang::UQS(list(a = 1, b = 2)))), ~list(a = 1, b = 2))
   expect_identical(quosure(rlang::UQF(~foo)), quosure(UQF(~foo)))
 

--- a/tests/testthat/test-tidy-unquote.R
+++ b/tests/testthat/test-tidy-unquote.R
@@ -20,14 +20,15 @@ test_that("interpolation is carried out in the right environment", {
   expect_identical(expr_interp(f), new_quosure("foo", env = f_env(f)))
 })
 
-test_that("interpolation does not revisit unquoted formulas", {
+test_that("interpolation now revisits unquoted formulas", {
   f <- ~list(!!~!!stop("should not interpolate within formulas"))
   f <- expr_interp(f)
-  expect_identical(expr_interp(f), f)
+  # This used to be idempotent:
+  expect_error(expect_false(identical(expr_interp(f), f)), "interpolate within formulas")
 })
 
 test_that("two-sided formulas are not treated as fpromises", {
-  expect_identical(expr(a ~ b), quote(a ~ b))
+  expect_identical(expr(a ~ b), quote(`_F`(a, b)))
 })
 
 test_that("unquote operators are always in scope", {


### PR DESCRIPTION
* This guards formulas on capture so we are compatible with purrr's lambdas cc @jennybc.

* This streamlines capture of literals so they are not rewrapped in a quosure. This should make it easier for instance to pass default `NULL` arguments between multiple NSE functions and check for a `NULL` quosure.