### PR TITLE
Rewrite predicate_pointer()

### DIFF
--- a/src/splice.c
+++ b/src/splice.c
@@ -189,7 +189,7 @@ static
 is_spliceable_t predicate_pointer(SEXP x) {
   switch (TYPEOF(x)) {
   case VECSXP:
-    if (Rf_inherits(x, "NativeSymbolInfo")) {
+    if (Rf_inherits(x, "NativeSymbolInfo") && Rf_length(x) >= 3) {
       SEXP ptr = VECTOR_ELT(x, 1);
       if (TYPEOF(ptr) == EXTPTRSXP) {
         return (is_spliceable_t) R_ExternalPtrAddr(ptr);

--- a/src/splice.c
+++ b/src/splice.c
@@ -187,25 +187,29 @@ bool is_spliced(SEXP x) {
 
 static
 is_spliceable_t predicate_pointer(SEXP x) {
-  is_spliceable_t is_spliceable;
-
   switch (TYPEOF(x)) {
   case VECSXP:
-    if (Rf_inherits(x, "NativeSymbolInfo") && Rf_length(x) == 3) {
+    if (Rf_inherits(x, "NativeSymbolInfo")) {
       SEXP ptr = VECTOR_ELT(x, 1);
       if (TYPEOF(ptr) == EXTPTRSXP) {
-        is_spliceable = (is_spliceable_t) R_ExternalPtrAddr(ptr);
-        break;
+        return (is_spliceable_t) R_ExternalPtrAddr(ptr);
+      }
+    } else if (Rf_length(x) == 1) {
+      SEXP ptr = VECTOR_ELT(x, 0);
+      if (TYPEOF(ptr) == EXTPTRSXP) {
+        return (is_spliceable_t) R_ExternalPtrAddr(ptr);
       }
     }
-  case EXTPTRSXP:
-    is_spliceable = (is_spliceable_t) R_ExternalPtrAddr(x);
     break;
+
+  case EXTPTRSXP:
+    return (is_spliceable_t) R_ExternalPtrAddr(x);
+
   default:
-    Rf_errorcall(R_NilValue, "`predicate` must be a closure or external pointer");
+    break;
   }
 
-  return is_spliceable;
+  Rf_errorcall(R_NilValue, "`predicate` must be a closure or external pointer");
 }
 
 is_spliceable_t predicate_internal(SEXP x) {


### PR DESCRIPTION
- safe aborting in case of error
- now also accepts an external pointer wrapped in a list
- ~~doesn't care about the length of a `NativeSymbolInfo`~~
- still accepts a naked external pointer, not sure about the usefulness here

See remarks in https://github.com/hadley/rlang/commit/04a9bce7f474f6740f9c6e3661ccb81b270c1ed9.