### PR TITLE
Fix forced dots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rlang
-Version: 0.0.0.9008
+Version: 0.0.0.9009
 Title: Tools for Language Objects and Evaluation
 Description: A toolbox for working with calls, unevaluated code, and
     anything related to evaluation in R.

--- a/R/compat-oldrel.R
+++ b/R/compat-oldrel.R
@@ -10,7 +10,7 @@
 #' @useDynLib rlang rlang_capturearg rlang_capturedots
 if (TRUE || utils::packageVersion("base") < "3.4.0") {
 
-  captureArg <- function(x) {
+  captureArg <- function(x, strict = TRUE) {
     caller_env <- parent.frame()
 
     if (identical(caller_env, globalenv())) {
@@ -20,7 +20,7 @@ if (TRUE || utils::packageVersion("base") < "3.4.0") {
       stop("argument \"x\" is missing")
     }
 
-    .Call(rlang_capturearg, NULL, NULL, pairlist(caller_env), get_env())
+    .Call(rlang_capturearg, NULL, NULL, pairlist(caller_env, strict), get_env())
   }
 
   captureDots <- function(strict = TRUE) {

--- a/R/compat-oldrel.R
+++ b/R/compat-oldrel.R
@@ -23,14 +23,14 @@ if (TRUE || utils::packageVersion("base") < "3.4.0") {
     .Call(rlang_capturearg, NULL, NULL, pairlist(caller_env), get_env())
   }
 
-  captureDots <- function() {
+  captureDots <- function(strict = TRUE) {
     caller_env <- parent.frame()
 
     if (!exists("...", caller_env)) {
       stop("must be called in a function where dots exist")
     }
 
-    .Call(rlang_capturedots, NULL, NULL, pairlist(caller_env), get_env())
+    .Call(rlang_capturedots, NULL, NULL, pairlist(caller_env, strict), get_env())
   }
 
 }

--- a/R/dots.R
+++ b/R/dots.R
@@ -65,8 +65,12 @@ dots_splice <- function(...) {
 #' flatten_if(dots, is_spliced)
 dots_values <- function(...) {
   dots <- dots_capture(..., `__quosured` = FALSE)
-  dots <- map(dots, function(dot) eval_bare(dot$expr, dot$env))
-  dots
+  if (is_null(dots)) {
+    dots <- list(...)
+    set_names(dots, names2(dots))
+  } else {
+    map(dots, function(dot) eval_bare(dot$expr, dot$env))
+  }
 }
 
 #' Inspect dots

--- a/R/quo-enquo.R
+++ b/R/quo-enquo.R
@@ -122,7 +122,13 @@ enexpr <- function(x) {
 }
 
 dots_capture <- function(..., `__interp_lhs` = TRUE, `__quosured` = TRUE) {
-  info <- captureDots()
+  info <- captureDots(strict = `__quosured`)
+
+  # No interpolation because dots were already evaluated
+  if (is_null(info)) {
+    return(NULL)
+  }
+
   dots <- map(info, dot_interp, quosured = `__quosured`)
 
   # Flatten possibly spliced dots

--- a/src/capture.c
+++ b/src/capture.c
@@ -45,6 +45,7 @@ SEXP attribute_hidden capture_promise(SEXP x, int strict) {
 
 SEXP attribute_hidden rlang_capturearg(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
+    int strict = asLogical(CADR(args));
     SEXP arg = findVarInFrame3(rho, install("x"), TRUE);
 
     if (TYPEOF(arg) == PROMSXP) {
@@ -55,7 +56,7 @@ SEXP attribute_hidden rlang_capturearg(SEXP call, SEXP op, SEXP args, SEXP rho)
             error(_("\"x\" must be an argument name"));
 
         arg = findVarInFrame3(caller_env, sym, TRUE);
-        return capture_promise(arg, 1);
+        return capture_promise(arg, strict);
     } else {
         // Argument was optimised away
         return capture_arg(arg, R_EmptyEnv);

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -68,3 +68,12 @@ test_that("interpolation by value does not guard formulas", {
 test_that("dots names can be unquoted", {
   expect_identical(dots_values(!! paste0("foo", "bar") := 10), list(foobar = 10))
 })
+
+test_that("can take forced dots with strict = FALSE", {
+  fn <- function(strict, ...) {
+    force(..1)
+    captureDots(strict)
+  }
+  expect_error(fn(TRUE, letters), "already been evaluated")
+  expect_identical(fn(FALSE, letters), NULL)
+})

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -77,3 +77,13 @@ test_that("can take forced dots with strict = FALSE", {
   expect_error(fn(TRUE, letters), "already been evaluated")
   expect_identical(fn(FALSE, letters), NULL)
 })
+
+test_that("dots_values() handles forced dots", {
+  fn <- function(...) {
+    force(..1)
+    dots_values(...)
+  }
+  expect_identical(fn("foo"), named_list("foo"))
+
+  expect_identical(lapply(1:2, function(...) dots_values(...)), list(named_list(1L), named_list(2L)))
+})

--- a/tests/testthat/test-tidy-capture.R
+++ b/tests/testthat/test-tidy-capture.R
@@ -215,3 +215,12 @@ test_that("expr() supports forwarded arguments", {
   g <- function(...) expr(...)
   expect_identical(fn(foo), quote(foo))
 })
+
+test_that("can take forced promise with strict = FALSE", {
+  fn <- function(strict, x) {
+    force(x)
+    captureArg(x, strict = strict)
+  }
+  expect_error(fn(TRUE, letters), "already been evaluated")
+  expect_identical(fn(FALSE, letters), NULL)
+})


### PR DESCRIPTION
This fixes some revdep failures in dplyr due to forced dots being passed to `bind_rows()`. E.g. in this situation:

```r
lapply(x, bind_rows)
```

Forced dots are returned as is when passed by value, and keep issuing an error if passed by expression.