### PR TITLE
Add `.ignore_empty` arg to dots_list() and dots_splice()

### DIFF
--- a/R/dots.R
+++ b/R/dots.R
@@ -11,6 +11,7 @@
 #' splicing semantics_: in addition to lists marked explicitly for
 #' splicing, [bare][is_bare_list] lists are spliced as well.
 #'
+#' @inheritParams dots_values
 #' @param ... Arguments with explicit (`dots_list()`) or list
 #'   (`dots_splice()`) splicing semantics. The contents of spliced
 #'   arguments are embedded in the returned list.
@@ -26,8 +27,9 @@
 #'
 #' # Unlike dots_splice(), it doesn't splice bare lists:
 #' dots_list(x, 3)
-dots_list <- function(...) {
-  dots <- .Call(rlang_squash, dots_values(...), "list", is_spliced, 1L)
+dots_list <- function(..., .ignore_empty = c("trailing", "none", "all")) {
+  dots <- dots_values(..., .ignore_empty = .ignore_empty)
+  dots <- .Call(rlang_squash, dots, "list", is_spliced, 1L)
   names(dots) <- names2(dots)
   dots
 }
@@ -40,8 +42,9 @@ dots_list <- function(...) {
 #' x <- list(1, 2)
 #' dots_splice(splice(x), 3)
 #' dots_splice(x, 3)
-dots_splice <- function(...) {
-  dots <- .Call(rlang_squash, dots_values(...), "list", is_spliced_bare, 1L)
+dots_splice <- function(..., .ignore_empty = c("trailing", "none", "all")) {
+  dots <- dots_values(..., .ignore_empty = .ignore_empty)
+  dots <- .Call(rlang_squash, dots, "list", is_spliced_bare, 1L)
   names(dots) <- names2(dots)
   dots
 }
@@ -56,6 +59,9 @@ dots_splice <- function(...) {
 #' a custom predicate (see [flatten_if()]).
 #'
 #' @param ... Arguments to evaluate and process splicing operators.
+#' @param .ignore_empty Whether to ignore empty arguments. Can be one
+#'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
+#'   last argument is ignored if it is empty.
 #' @export
 #' @examples
 #' dots <- dots_values(!!! list(1))
@@ -63,8 +69,9 @@ dots_splice <- function(...) {
 #'
 #' # Flatten the spliced objects:
 #' flatten_if(dots, is_spliced)
-dots_values <- function(...) {
+dots_values <- function(..., .ignore_empty = c("trailing", "none", "all")) {
   dots <- dots_capture(..., `__quosured` = FALSE)
+  dots <- dots_clean_empty(dots, function(x) is_missing(x$expr), .ignore_empty)
   if (is_null(dots)) {
     dots <- list(...)
     set_names(dots, names2(dots))

--- a/R/dots.R
+++ b/R/dots.R
@@ -73,6 +73,25 @@ dots_values <- function(...) {
   }
 }
 
+dots_clean_empty <- function(dots, is_empty, ignore_empty) {
+  n_dots <- length(dots)
+
+  if (n_dots) {
+    which <- match.arg(ignore_empty, c("trailing", "none", "all"))
+    switch(which,
+      trailing =
+        if (is_empty(dots[[n_dots]])) {
+          dots[[n_dots]] <- NULL
+        },
+      all = {
+        dots <- discard(dots, is_empty)
+      }
+    )
+  }
+
+  dots
+}
+
 #' Inspect dots
 #'
 #' Runs [arg_inspect()] for each dots element, and return the results

--- a/R/quos.R
+++ b/R/quos.R
@@ -70,21 +70,7 @@
 quos <- function(..., .named = FALSE,
                  .ignore_empty = c("trailing", "none", "all")) {
   dots <- dots_enquose(...)
-
-  n_dots <- length(dots)
-  if (n_dots) {
-    dots <- switch(match.arg(.ignore_empty),
-      trailing =
-        if (quo_is_missing(dots[[n_dots]])) {
-          dots[[n_dots]] <- NULL
-          dots
-        } else {
-          dots
-        },
-      all = discard(dots, quo_is_missing),
-      dots
-    )
-  }
+  dots <- dots_clean_empty(dots, quo_is_missing, .ignore_empty)
 
   if (.named) {
     width <- quo_names_width(.named)

--- a/R/quos.R
+++ b/R/quos.R
@@ -21,14 +21,12 @@
 #'    RHS. Unlike `dots_quos()`, it allows named definitions.}
 #' }
 #' @inheritParams enquo
+#' @inheritParams dots_values
 #' @param .named Whether to ensure all dots are named. Unnamed
 #'   elements are processed with [expr_text()] to figure out a default
 #'   name. If an integer, it is passed to the `width` argument of
 #'   `expr_text()`, if `TRUE`, the default width is used. See
 #'   [exprs_auto_name()].
-#' @param .ignore_empty Whether to ignore empty arguments. Can be one
-#'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
-#'   last argument is ignored if it is empty.
 #' @export
 #' @name quosures
 #' @examples

--- a/man/dots_list.Rd
+++ b/man/dots_list.Rd
@@ -5,14 +5,18 @@
 \alias{dots_splice}
 \title{Extract dots with splicing semantics.}
 \usage{
-dots_list(...)
+dots_list(..., .ignore_empty = c("trailing", "none", "all"))
 
-dots_splice(...)
+dots_splice(..., .ignore_empty = c("trailing", "none", "all"))
 }
 \arguments{
 \item{...}{Arguments with explicit (\code{dots_list()}) or list
 (\code{dots_splice()}) splicing semantics. The contents of spliced
 arguments are embedded in the returned list.}
+
+\item{.ignore_empty}{Whether to ignore empty arguments. Can be one
+of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
+last argument is ignored if it is empty.}
 }
 \value{
 A list of arguments. This list is always named: unnamed

--- a/man/dots_values.Rd
+++ b/man/dots_values.Rd
@@ -4,10 +4,14 @@
 \alias{dots_values}
 \title{Evaluate dots with preliminary splicing.}
 \usage{
-dots_values(...)
+dots_values(..., .ignore_empty = c("trailing", "none", "all"))
 }
 \arguments{
 \item{...}{Arguments to evaluate and process splicing operators.}
+
+\item{.ignore_empty}{Whether to ignore empty arguments. Can be one
+of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
+last argument is ignored if it is empty.}
 }
 \description{
 This is a tool for advanced users. It captures dots, processes

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -87,3 +87,10 @@ test_that("dots_values() handles forced dots", {
 
   expect_identical(lapply(1:2, function(...) dots_values(...)), list(named_list(1L), named_list(2L)))
 })
+
+test_that("cleans empty arguments", {
+  expect_identical(dots_list(1, a = ), named_list(1))
+  expect_identical(ll(1, a = ), list(1))
+
+  expect_identical(dots_list(, 1, a = , .ignore_empty = "all"), named_list(1))
+})


### PR DESCRIPTION
So all functions taking dots by value now trim trailing empty arguments by default. E.g.

```r
chr("a", )
#> [1] "a"
```